### PR TITLE
Use <$> from Data.Functor under ghc-7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# NB: don't set `language: haskell` here
+
+# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
+env:
+ - CABALVER=1.16 GHCVER=7.4.2
+ - CABALVER=1.18 GHCVER=7.6.3
+ - CABALVER=1.18 GHCVER=7.8.3
+ - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ # - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# The following scriptlet checks that the resulting source distribution can be built & installed
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+   cd dist/;
+   if [ -f "$SRC_TGZ" ]; then
+      cabal install --force-reinstalls "$SRC_TGZ";
+   else
+      echo "expected '$SRC_TGZ' not found";
+      exit 1;
+   fi

--- a/Language/Haskell/TH/ExpandSyns.hs
+++ b/Language/Haskell/TH/ExpandSyns.hs
@@ -12,6 +12,9 @@ import Language.Haskell.TH hiding(cxt)
 import qualified Data.Set as Set
 import Data.Generics
 import Control.Monad
+#if __GLASGOW_HASKELL__ >= 709
+import Data.Functor ((<$>))
+#endif
 
 -- For ghci
 #ifndef MIN_VERSION_template_haskell
@@ -58,9 +61,10 @@ tyVarBndrSetName n _ = n
 #endif
 
 
-
+#if __GLASGOW_HASKELL__ < 709
 (<$>) :: (Functor f) => (a -> b) -> f a -> f b
 (<$>) = fmap
+#endif
 (<*>) :: (Monad m) => m (a -> b) -> m a -> m b
 (<*>) = ap
 


### PR DESCRIPTION
I don't quite understand why import of Data.Functor.<$> is redundant in the travis build, but seems to be required when I build using cabal build.