### PR TITLE
Support GHC 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.1
+      compiler: ": #GHC 8.2.1"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       compiler: ": #GHC head"
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}

--- a/Language/Haskell/TH/ExpandSyns.hs
+++ b/Language/Haskell/TH/ExpandSyns.hs
@@ -126,6 +126,9 @@ nameIsSyn settings n = do
     DataConI {} -> no
     VarI {} -> no
     TyVarI {} -> no
+#if MIN_VERSION_template_haskell(2,12,0)
+    PatSynI {} -> no
+#endif
 
   where
     no = return Nothing
@@ -184,6 +187,11 @@ decIsSyn settings = go
 #if MIN_VERSION_template_haskell(2,10,0)
     go (StandaloneDerivD {}) = no
     go (DefaultSigD {}) = no
+#endif
+
+#if MIN_VERSION_template_haskell(2,12,0)
+    go (PatSynD {}) = no
+    go (PatSynSigD {}) = no
 #endif
 
     no = return Nothing
@@ -312,6 +320,10 @@ expandSynsWith settings = expandSyns'
       go acc x@WildCardT = passThrough acc x
 #endif
 
+#if MIN_VERSION_template_haskell(2,12,0)
+      go acc x@(UnboxedSumT _) = passThrough acc x
+#endif
+
 class SubstTypeVariable a where
     -- | Capture-free substitution
     subst :: (Name, Type) -> a -> a
@@ -359,6 +371,10 @@ instance SubstTypeVariable Type where
       go (UInfixT t1 nm t2) = UInfixT (go t1) nm (go t2)
       go (ParensT t1) = ParensT (go t1)
       go s@WildCardT = s
+#endif
+
+#if MIN_VERSION_template_haskell(2,12,0)
+      go s@(UnboxedSumT _) = s
 #endif
 
 -- testCapture :: Type

--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -19,14 +19,14 @@ tested-with:
     GHC == 7.8.4
     GHC == 7.10.3
     GHC == 8.0.1
-    GHC == 8.1
+    GHC == 8.2.1
 
 source-repository head
  type: git
  location: git://github.com/DanielSchuessler/th-expand-syns.git
 
 Library
-    build-depends:       base >= 4 && < 5, template-haskell < 2.12, syb, containers
+    build-depends:       base >= 4 && < 5, template-haskell < 2.13, syb, containers
     ghc-options:
     exposed-modules:     Language.Haskell.TH.ExpandSyns
 


### PR DESCRIPTION
`th-expand-syns` only requires minor tweaks to cover some new `template-haskell` AST forms introduced in 2.12.