### PR TITLE
Bump the version bound on template-haskell to 2.16.

### DIFF
--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -28,7 +28,7 @@ source-repository head
  location: git://github.com/DanielSchuessler/th-expand-syns.git
 
 Library
-    build-depends:       base >= 4 && < 5, template-haskell < 2.15, syb, containers
+    build-depends:       base >= 4 && < 5, template-haskell < 2.16, syb, containers
     ghc-options:
     exposed-modules:     Language.Haskell.TH.ExpandSyns
     other-modules:       Language.Haskell.TH.ExpandSyns.SemigroupCompat


### PR DESCRIPTION
I have verified that the test suite still passes.  (However, instead of this change, I would recommend just leaving off the upper bound entirely.)