### PR TITLE
 Support new features in template-haskell-2.15.* 

### DIFF
--- a/Language/Haskell/TH/ExpandSyns.hs
+++ b/Language/Haskell/TH/ExpandSyns.hs
@@ -16,6 +16,7 @@ import Language.Haskell.TH.ExpandSyns.SemigroupCompat as Sem
 import Language.Haskell.TH hiding(cxt)
 import qualified Data.Set as Set
 import Data.Generics
+import Data.Maybe
 import Control.Monad
 import Prelude
 
@@ -201,6 +202,10 @@ decIsSyn settings = go
     go (PatSynSigD {}) = no
 #endif
 
+#if MIN_VERSION_template_haskell(2,15,0)
+    go (ImplicitParamBindD {}) = no
+#endif
+
     no = return Nothing
 
 #if MIN_VERSION_template_haskell(2,4,0)
@@ -229,18 +234,38 @@ expandSynsWith settings = expandSyns'
       expandSyns' t =
          do
            (acc,t') <- go [] t
-           return (foldl AppT t' acc)
+           return (foldl applyTypeArg t' acc)
 
 #if MIN_VERSION_template_haskell(2,4,0)
       expandKindSyns' k =
 # if MIN_VERSION_template_haskell(2,8,0)
          do
            (acc,k') <- go [] k
-           return (foldl AppT k' acc)
+           return (foldl applyTypeArg k' acc)
 # else
          return k -- No kind variables on old versions of GHC
 # endif
 #endif
+
+      applyTypeArg :: Type -> TypeArg -> Type
+      applyTypeArg f (TANormal x) = f `AppT` x
+      applyTypeArg f (TyArg _x)   =
+#if __GLASGOW_HASKELL__ >= 807
+                                    f `AppKindT` _x
+#else
+                                    -- VKA isn't supported, so
+                                    -- conservatively drop the argument
+                                    f
+#endif
+
+
+      -- Filter the normal type arguments from a list of TypeArgs.
+      filterTANormals :: [TypeArg] -> [Type]
+      filterTANormals = mapMaybe getTANormal
+        where
+          getTANormal :: TypeArg -> Maybe Type
+          getTANormal (TANormal t) = Just t
+          getTANormal (TyArg {})   = Nothing
 
       -- Must only be called on an `x' requiring no expansion
       passThrough acc x = return (acc, x)
@@ -253,7 +278,7 @@ expandSynsWith settings = expandSyns'
       --  All elements of `args'' and `t'' are expanded.
       --  `t' applied to `args' equals `t'' applied to `args'' (up to expansion, of course)
 
-      go :: [Type] -> Type -> Q ([Type], Type)
+      go :: [TypeArg] -> Type -> Q ([TypeArg], Type)
 
       go acc x@ListT = passThrough acc x
       go acc x@ArrowT = passThrough acc x
@@ -273,7 +298,7 @@ expandSynsWith settings = expandSyns'
       go acc (AppT t1 t2) =
           do
             r <- expandSyns' t2
-            go (r:acc) t1
+            go (TANormal r:acc) t1
 
       go acc x@(ConT n) =
           do
@@ -285,7 +310,7 @@ expandSynsWith settings = expandSyns'
                   then fail (packagename++": expandSynsWith: Underapplied type synonym: "++show(n,acc))
                   else
                       let
-                          substs = zip vars acc
+                          substs = zip vars (filterTANormals acc)
                           expanded = foldr subst body substs
                       in
                         go (drop (length vars) acc) expanded
@@ -339,6 +364,24 @@ expandSynsWith settings = expandSyns'
       go acc x@(UnboxedSumT _) = passThrough acc x
 #endif
 
+#if MIN_VERSION_template_haskell(2,15,0)
+      go acc (AppKindT t k) =
+          do
+            k' <- expandKindSyns' k
+            go (TyArg k':acc) t
+      go acc (ImplicitParamT n t) =
+          do
+            (acc',t') <- go acc t
+            return (acc',ImplicitParamT n t')
+#endif
+
+-- | An argument to a type, either a normal type ('TANormal') or a visible
+-- kind application ('TyArg').
+data TypeArg
+  = TANormal Type -- Normal arguments
+  | TyArg    Kind -- Visible kind applications
+  deriving Show
+
 class SubstTypeVariable a where
     -- | Capture-free substitution
     subst :: (Name, Type) -> a -> a
@@ -390,6 +433,11 @@ instance SubstTypeVariable Type where
 
 #if MIN_VERSION_template_haskell(2,12,0)
       go s@(UnboxedSumT _) = s
+#endif
+
+#if MIN_VERSION_template_haskell(2,15,0)
+      go (AppKindT ty ki) = AppKindT (go ty) (go ki)
+      go (ImplicitParamT n ty) = ImplicitParamT n (go ty)
 #endif
 
 -- testCapture :: Type

--- a/testing/Main.hs
+++ b/testing/Main.hs
@@ -68,6 +68,13 @@ main = do
         [t| Int'' |]
         [t| Int |])
 
+#if MIN_VERSION_template_haskell(2,8,0)
+    putStrLn "Synonyms in kinds"
+    $(mkTest
+        (sigT (conT ''Int) (ConT ''Id `AppT` StarT))
+        (sigT (conT ''Int) StarT))
+#endif
+
     $(do
         reportWarning "No warning about type families should appear after this line." -- TODO: Automate this test with a custom Quasi instance?
         _ <- expandSynsWith noWarnTypeFamilies =<< [t| (DF1 Int', TF1 Int', AT1 Int') |]

--- a/testing/Types.hs
+++ b/testing/Types.hs
@@ -16,6 +16,7 @@ type ApplyToInteger f = f Integer
 type Int' = Int
 type Either' = Either
 type Int'' = Int
+type Id a = a
 
 -- type E x = forall y. Either x y -> Int
 $(sequence [tySynD (mkName "E") [PlainTV (mkName "x")]

--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -28,7 +28,7 @@ source-repository head
  location: git://github.com/DanielSchuessler/th-expand-syns.git
 
 Library
-    build-depends:       base >= 4 && < 5, template-haskell < 2.15, syb, containers
+    build-depends:       base >= 4 && < 5, template-haskell < 2.16, syb, containers
     ghc-options:
     exposed-modules:     Language.Haskell.TH.ExpandSyns
     other-modules:       Language.Haskell.TH.ExpandSyns.SemigroupCompat


### PR DESCRIPTION
This adds support for `AppKindT` (visible kind applications) and `ImplicitParamT` (implicit parameter constraints) in `expandSyns`. I had to do some slight refactoring in `expandSyns'` to make this happen since it is possible for visible kind arguments and other arguments to be in any order (e.g., `Foo @t1 T2 @T3 T4`), so I needed to add an auxiliary `TypeArg` data type to distinguish between them.

This builds on top of the machinery in #14, so this subsumes #14. Also, this subsumes #12.