### PR TITLE
Support template-haskell-2.16.0.0

### DIFF
--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -23,7 +23,7 @@ source-repository head
  location: git://github.com/DanielSchuessler/th-expand-syns.git
 
 Library
-    build-depends:       base >= 4 && < 5, template-haskell < 2.16, syb, containers
+    build-depends:       base >= 4 && < 5, template-haskell < 2.17, syb, containers
     ghc-options:
     exposed-modules:     Language.Haskell.TH.ExpandSyns
     other-modules:       Language.Haskell.TH.ExpandSyns.SemigroupCompat


### PR DESCRIPTION
`template-haskell-2.16.0.0` (bundled with GHC 8.10) adds new constructors to `Dec` and `Type`. This patch handles them like so:

* There is a new `DKiSigD` constructor for standalone kind signatures. These are immaterial to `decIsSyn`, so this patch makes `decIsSyn` return `Nothing` when it encounters a `DKiSigD`.
* There is a new `ForallVisT` constructor for visible dependent quantification. This is handled very similarly to the existing cases for `ForallT` in `expandSynsWith` and `subst`. I ended up needing to tweak `commonForallCase` slightly to accommodate `ForallVisT` since `commonForallCase` assumes the presence of a `Cxt`, which `ForallVisT` lacks.