### PR TITLE
Support template-haskell-2.17

### DIFF
--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -23,7 +23,7 @@ source-repository head
  location: git://github.com/DanielSchuessler/th-expand-syns.git
 
 Library
-    build-depends:       base >= 4 && < 5, template-haskell < 2.17, syb, containers
+    build-depends:       base >= 4 && < 5, template-haskell < 2.18, syb, containers
     ghc-options:
     exposed-modules:     Language.Haskell.TH.ExpandSyns
     other-modules:       Language.Haskell.TH.ExpandSyns.SemigroupCompat


### PR DESCRIPTION
Hi, it looks like this package compiles fine with the new template-haskell, though I haven't tested at runtime. Would you be able to bump the version for it?