### PR TITLE
Make th-expand-syns a shim on top of th-abstraction

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12
+# version: 0.13.20210827
 #
-# REGENDATA ("0.12",["github","cabal.project"])
+# REGENDATA ("0.13.20210827",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -26,65 +26,129 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.0.20210821
+            compilerKind: ghc
+            compilerVersion: 9.2.0.20210821
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.10.3
+            compilerKind: ghc
+            compilerVersion: 7.10.3
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.8.4
+            compilerKind: ghc
+            compilerVersion: 7.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.6.3
+            compilerKind: ghc
+            compilerVersion: 7.6.3
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.4.2
+            compilerKind: ghc
+            compilerVersion: 7.4.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.2.2
+            compilerKind: ghc
+            compilerVersion: 7.2.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.0.4
+            compilerKind: ghc
+            compilerVersion: 7.0.4
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y $CC cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.4.0.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME" cabal-install-3.4
+          fi
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
-          HCNAME=ghc
-          HC=$HCDIR/bin/$HCNAME
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.4.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -107,6 +171,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -145,7 +220,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_th_expand_syns="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/th-expand-syns-[0-9.]*')"
-          echo "PKGDIR_th_expand_syns=${PKGDIR_th_expand_syns}" >> $GITHUB_ENV
+          echo "PKGDIR_th_expand_syns=${PKGDIR_th_expand_syns}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_th_expand_syns}" >> cabal.project
@@ -153,6 +229,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(th-expand-syns)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/README.markdown
+++ b/README.markdown
@@ -13,3 +13,19 @@
   "The Haskell Programming Language"
 
 Expands type synonyms in Template Haskell ASTs.
+
+As of version `0.4.9.0`, this library is a small shim on top of the
+`applySubstitution`/`resolveTypeSynonyms` functions from `th-abstraction`, so
+you may want to consider using `th-abstraction` instead. The only pieces of
+functionality that `th-expand-syns` provides which are not currently present in
+`th-abstraction` are:
+
+* `th-expand-syns`' `expandSyns{With}` functions will warn that they cannot
+  expand type families (if the `SynonymExpansionSettings` are configured to
+  check for this). By contrast, `th-abstraction`'s `applySubstitution`
+  function will silently ignore type families.
+* `th-expand-syns` provides a `substInCon` function which allows substitution
+  into `Con`s.
+* `th-expand-syns` provides `evade{s}` functions which support type variable
+  `Name` freshening that calculating the free variables in any type that
+  provides an instance of `Data`.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,2 +1,4 @@
+distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
+ghcup-jobs:             >=8.10

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,3 +1,21 @@
+## 0.4.9.0 [????.??.??]
+
+* Consolidate the type-synonym expansion functionality with `th-abstraction`,
+  which also provides the ability to expand type synonyms. After this change,
+  the `th-expand-syns` library is mostly a small shim on top of
+  `th-abstraction`. The only additional pieces of functionality that
+  `th-expand-syns` which aren't currently available in `th-abstraction` are:
+
+  * `th-expand-syns`' `expandSyns{With}` functions will warn that they cannot
+    expand type families (if the `SynonymExpansionSettings` are configured to
+    check for this). By contrast, `th-abstraction`'s `applySubstitution`
+    function will silently ignore type families.
+  * `th-expand-syns` provides a `substInCon` function which allows substitution
+    into `Con`s.
+  * `th-expand-syns` provides `evade{s}` functions which support type variable
+    `Name` freshening that calculating the free variables in any type that
+    provides an instance of `Data`.
+
 ## 0.4.8.0 [2021.03.12]
 
 * Make the test suite compile with GHC 9.0 or later.

--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -1,7 +1,12 @@
 name:                th-expand-syns
-version:             0.4.8.0
+version:             0.4.9.0
 synopsis:            Expands type synonyms in Template Haskell ASTs
 description:         Expands type synonyms in Template Haskell ASTs.
+                     .
+                     As of version @0.4.9.0@, this library is a small shim on
+                     top of the @applySubstitution@/@resolveTypeSynonyms@
+                     functions from @th-abstraction@, so you may want to
+                     consider using @th-abstraction@ instead.
 category:            Template Haskell
 license:             BSD3
 license-file:        LICENSE
@@ -23,19 +28,20 @@ tested-with:
     GHC == 8.4.4
     GHC == 8.6.5
     GHC == 8.8.4
-    GHC == 8.10.4
+    GHC == 8.10.7
     GHC == 9.0.1
+    GHC == 9.2.*
 
 source-repository head
  type: git
  location: https://github.com/DanielSchuessler/th-expand-syns.git
 
 Library
-    build-depends:       base             >= 4.3 && < 5
+    build-depends:       base             >= 4.3   && < 5
                        , containers
                        , syb
-                       , th-abstraction   >= 0.4 && < 0.5
-                       , template-haskell >= 2.5 && < 2.18
+                       , th-abstraction   >= 0.4.3 && < 0.5
+                       , template-haskell >= 2.5   && < 2.19
     ghc-options:         -Wall
     exposed-modules:     Language.Haskell.TH.ExpandSyns
     other-modules:       Language.Haskell.TH.ExpandSyns.SemigroupCompat


### PR DESCRIPTION
This replaces `th-expand-syns`' substitution and type expansion machinery with that of `th-abstraction`, which provides essentially the same functionality. After this change, `th-expand-syns` becomes, for the most part, a small shim on top of `th-abstraction`. There are still a few pieces of functionality which `th-expand-syns` provides over `th-abstraction` (see the `README`), but these are mostly minor things.

Fixes #23.