### PR TITLE
Fix warnings when building with GHC 9.4

### DIFF
--- a/Language/Haskell/TH/ExpandSyns.hs
+++ b/Language/Haskell/TH/ExpandSyns.hs
@@ -159,6 +159,10 @@ warnIfDecIsTypeFamily = go
     go (KiSigD {}) = return ()
 #endif
 
+#if MIN_VERSION_template_haskell(2,19,0)
+    go (DefaultD {}) = return ()
+#endif
+
 warnTypeFamiliesInType :: Type -> Q ()
 warnTypeFamiliesInType = go
   where
@@ -215,6 +219,16 @@ warnTypeFamiliesInType = go
 #endif
 #if MIN_VERSION_template_haskell(2,17,0)
     go MulArrowT{} = return ()
+#endif
+#if MIN_VERSION_template_haskell(2,19,0)
+    go (PromotedInfixT t1 n t2) = do
+      warnIfNameIsTypeFamily n
+      go t1
+      go t2
+    go (PromotedUInfixT t1 n t2) = do
+      warnIfNameIsTypeFamily n
+      go t1
+      go t2
 #endif
 
     go_kind :: Kind -> Q ()

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,3 +1,8 @@
+## next [????.??.??]
+
+* Support `DefaultD`, `PromotedInfixT`, and `PromotedUInfixT` when building
+  with `template-haskell-2.19.0.0` (GHC 9.4) or later.
+
 ## 0.4.9.0 [2021.08.30]
 
 * Consolidate the type-synonym expansion functionality with `th-abstraction`,

--- a/th-expand-syns.cabal
+++ b/th-expand-syns.cabal
@@ -41,7 +41,7 @@ Library
                        , containers
                        , syb
                        , th-abstraction   >= 0.4.3 && < 0.5
-                       , template-haskell >= 2.5   && < 2.19
+                       , template-haskell >= 2.5   && < 2.20
     ghc-options:         -Wall
     exposed-modules:     Language.Haskell.TH.ExpandSyns
     other-modules:       Language.Haskell.TH.ExpandSyns.SemigroupCompat


### PR DESCRIPTION
This adds appropriate cases for `DefaultD`, `PromotedInfixT`, and `PromotedUInfixT`, which were added in `template-haskell-2.19.0.0` (GHC 9.4).